### PR TITLE
Feat/customize errors

### DIFF
--- a/plutto/constants.py
+++ b/plutto/constants.py
@@ -2,3 +2,4 @@
 
 API_BASE_URL = "https://sandbox.getplutto.com/api"
 API_VERSION = "v1"
+GENERAL_DOC_URL = 'https://docs.getplutto.com/'

--- a/plutto/errors.py
+++ b/plutto/errors.py
@@ -1,0 +1,47 @@
+"""Module to hold the Plutto custom errors."""
+from .constants import GENERAL_DOC_URL
+
+class PluttoError(Exception):
+    """Represents the base custom error."""
+
+    def __init__(self, error_data, doc_url=GENERAL_DOC_URL):
+        error_type = error_data.get("type")
+        error_code = error_data.get("code")
+        error_message = error_data.get("message")
+        error_param = error_data.get("param")
+        message = error_type
+        message += f": {error_code}" if error_code else ""
+        message += f" ({error_param})" if error_param else ""
+        message += f"\n{error_message}"
+        message += f"\nCheck the docs for more info: {doc_url}"
+
+        super().__init__(message)
+
+
+class InvalidRequestError(PluttoError):
+    """Represents the invalid request error."""
+
+
+class BadRequestError(PluttoError):
+    """Represent the bad request error."""
+
+class UnprocessableEntityError(PluttoError):
+    """Represents the unprocessable entity error."""
+
+
+class UnauthorizedError(PluttoError):
+    """Represents the unauthorized entity error."""
+
+
+class NotFoundError(PluttoError):
+    """Represents the not found error."""
+
+
+class InternalServerError(PluttoError):
+    """Represents the internal server error."""
+
+
+class AuthenticationError(PluttoError):
+    """Represents the authentication error."""
+
+

--- a/plutto/mixins/manager_mixin.py
+++ b/plutto/mixins/manager_mixin.py
@@ -3,7 +3,7 @@
 from abc import ABCMeta, abstractmethod
 
 from plutto.resource_handlers import resource_all
-from plutto.utils import get_resource_class, pluralize
+from plutto.utils import get_resource_class, pluralize, can_raise_http_error
 
 class ManagerMixin(metaclass=ABCMeta):
     """Class to hold the mixin for the managers."""
@@ -42,6 +42,7 @@ class ManagerMixin(metaclass=ABCMeta):
         ['all', 'get', 'create', 'update', 'delete'].
         """
 
+    @can_raise_http_error
     def _all(self, **kwargs):
         """
         Method to fetch all objects.

--- a/plutto/utils.py
+++ b/plutto/utils.py
@@ -1,8 +1,12 @@
 from importlib import import_module
 
+from plutto.errors import PluttoError
+
+
 def singularize(string):
     """Remove the last 's' from a string if exists."""
     return string.rstrip("s")
+
 
 def pluralize(string):
     """Add an 's' to a string if it doesn't already end with 's'."""
@@ -10,9 +14,11 @@ def pluralize(string):
         return string
     return string + "s"
 
+
 def snake_to_pascal(snake_string):
     """Convert a snake_case string to PascalCase."""
     return ''.join(word.title() for word in snake_string.split('_'))
+
 
 def get_resource_class(snake_resource_name, value={}):
     """
@@ -26,6 +32,16 @@ def get_resource_class(snake_resource_name, value={}):
         except AttributeError:
             return getattr(module, "GenericPluttoResource")
     return type(value)
+
+
+def get_error_class(function):
+    """
+    Given an error name (in snake case), return the appropiate
+    error class.
+    """
+    module = import_module("plutto.errors")
+    return getattr(module, snake_to_pascal(function), PluttoError)
+
 
 def objetize(klass, client, data, handlers={}, methods=[], path=None):
     """Transform the :data: object into an object with class :klass:"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,11 @@
+from plutto.errors import PluttoError, AuthenticationError
 from plutto.resources import Customer
 from plutto.utils import (
     singularize,
     pluralize,
     snake_to_pascal,
     get_resource_class,
+    get_error_class,
     objetize,
 )
 
@@ -74,6 +76,18 @@ class TestGetResourceClass:
         resource = "anyone"
         klass = get_resource_class(resource, value=True)
         assert klass is bool
+
+
+class TestGetErrorClass:
+    def test_valid_error(self):
+        error_name = "authentication_error"
+        error = get_error_class(error_name)
+        assert error is AuthenticationError
+
+    def test_invalid_error(self):
+        error_name = "invalid_error"
+        error = get_error_class(error_name)
+        assert error is PluttoError
 
 
 class ExampleClass:


### PR DESCRIPTION
Se definen los errors custom en base a los existentes en la SDK de Ruby y un par de Fintoc. Se agrega una función que identifica que clase de error es, para transformar ese error de HTTP a uno custom. Finalmente, se encapsula la lógica en un decorador, que se aplicará sobre cada método del `ManagerMixin`, para levantar los errores custom en vez de los HTPP
