### PR TITLE
Test/fix mocks

### DIFF
--- a/plutto/constants.py
+++ b/plutto/constants.py
@@ -2,3 +2,4 @@
 
 API_BASE_URL = "https://sandbox.getplutto.com/api"
 API_VERSION = "v1"
+GENERAL_DOC_URL = 'https://docs.getplutto.com/'

--- a/plutto/errors.py
+++ b/plutto/errors.py
@@ -1,0 +1,47 @@
+"""Module to hold the Plutto custom errors."""
+from .constants import GENERAL_DOC_URL
+
+class PluttoError(Exception):
+    """Represents the base custom error."""
+
+    def __init__(self, error_data, doc_url=GENERAL_DOC_URL):
+        error_type = error_data.get("type")
+        error_code = error_data.get("code")
+        error_message = error_data.get("message")
+        error_param = error_data.get("param")
+        message = error_type
+        message += f": {error_code}" if error_code else ""
+        message += f" ({error_param})" if error_param else ""
+        message += f"\n{error_message}"
+        message += f"\nCheck the docs for more info: {doc_url}"
+
+        super().__init__(message)
+
+
+class InvalidRequestError(PluttoError):
+    """Represents the invalid request error."""
+
+
+class BadRequestError(PluttoError):
+    """Represent the bad request error."""
+
+class UnprocessableEntityError(PluttoError):
+    """Represents the unprocessable entity error."""
+
+
+class UnauthorizedError(PluttoError):
+    """Represents the unauthorized entity error."""
+
+
+class NotFoundError(PluttoError):
+    """Represents the not found error."""
+
+
+class InternalServerError(PluttoError):
+    """Represents the internal server error."""
+
+
+class AuthenticationError(PluttoError):
+    """Represents the authentication error."""
+
+

--- a/plutto/managers/customers_manager.py
+++ b/plutto/managers/customers_manager.py
@@ -6,5 +6,5 @@ class CustomersManager(ManagerMixin):
     """Class to hold the customers manager."""
 
     resource = "customer"
-    methods = ["all"]
+    methods = ["all", "get", "create", "update", "delete"]
 

--- a/plutto/mixins/manager_mixin.py
+++ b/plutto/mixins/manager_mixin.py
@@ -107,6 +107,15 @@ class ManagerMixin(metaclass=ABCMeta):
         object_ = self._get(unique_identifier)
         return object_.update(**kwargs)
 
+    @can_raise_http_error
+    def _delete(self, identifier, **kwargs):
+        """
+        Delete an instance of the resource being handled by the manager,
+        identified by :identifier:.
+        """
+        object_ = self._get(identifier)
+        return object_.delete(**kwargs)
+
     def post_all_handler(self, objects, **kwargs):
         """
         Hook that runs after the :all: method. Receives the objects fetched
@@ -129,7 +138,7 @@ class ManagerMixin(metaclass=ABCMeta):
         """
         return object_
 
-    def post_update_handler(self, object_, identifier, **kwargs):
+    def post_update_handler(self, object_, unique_identifier, **kwargs):
         """
         Hook that runs after the :update: method. Receives the object fetched
         with its identifier and **must** return the object (either modified

--- a/plutto/mixins/manager_mixin.py
+++ b/plutto/mixins/manager_mixin.py
@@ -80,6 +80,23 @@ class ManagerMixin(metaclass=ABCMeta):
         )
         return self.post_get_handler(object_, identifier, **kwargs)
 
+    @can_raise_http_error
+    def _create(self, **kwargs):
+        """
+        Create an instance of the resource being handled by the manager.
+        Data is passed using :kwargs:, as specified by the API.
+        """
+        klass = get_resource_class(self.__class__.resource)
+        object_ = resource_create(
+            client=self._client,
+            path=self._path,
+            klass=klass,
+            handlers=self._handlers,
+            methods=self.__class__.methods,
+            params=kwargs,
+        )
+        return self.post_create_handler(object_, **kwargs)
+
     def post_all_handler(self, objects, **kwargs):
         """
         Hook that runs after the :all: method. Receives the objects fetched

--- a/plutto/mixins/manager_mixin.py
+++ b/plutto/mixins/manager_mixin.py
@@ -2,7 +2,7 @@
 
 from abc import ABCMeta, abstractmethod
 
-from plutto.resource_handlers import resource_all
+from plutto.resource_handlers import resource_all, resource_get, resource_create
 from plutto.utils import get_resource_class, pluralize, can_raise_http_error
 
 class ManagerMixin(metaclass=ABCMeta):
@@ -60,6 +60,25 @@ class ManagerMixin(metaclass=ABCMeta):
             params=kwargs,
         )
         return self.post_all_handler(objects, **kwargs)
+
+    @can_raise_http_error
+    def _get(self, identifier, **kwargs):
+        """
+        Return an instanco of the resource being handled by the manager,
+        indentified by :identifier:.
+        """
+        klass = get_resource_class(self.__class__.resource)
+        object_ = resource_get(
+            client=self._client,
+            path=self._path,
+            id_=identifier,
+            klass=klass,
+            handlers=self._handlers,
+            methods=self.__class__.methods,
+            resource=self.__class__.resource,
+            params=kwargs,
+        )
+        return self.post_get_handler(object_, identifier, **kwargs)
 
     def post_all_handler(self, objects, **kwargs):
         """

--- a/plutto/mixins/manager_mixin.py
+++ b/plutto/mixins/manager_mixin.py
@@ -97,6 +97,16 @@ class ManagerMixin(metaclass=ABCMeta):
         )
         return self.post_create_handler(object_, **kwargs)
 
+    @can_raise_http_error
+    def _update(self, unique_identifier, **kwargs):
+        """
+        Update an instance of the resource being handled by the manager,
+        identified by :identifier:. Data is passed using :kwargs:, as
+        specified by the API.
+        """
+        object_ = self._get(unique_identifier)
+        return object_.update(**kwargs)
+
     def post_all_handler(self, objects, **kwargs):
         """
         Hook that runs after the :all: method. Receives the objects fetched

--- a/plutto/mixins/manager_mixin.py
+++ b/plutto/mixins/manager_mixin.py
@@ -3,7 +3,7 @@
 from abc import ABCMeta, abstractmethod
 
 from plutto.resource_handlers import resource_all
-from plutto.utils import get_resource_class, pluralize
+from plutto.utils import get_resource_class, pluralize, can_raise_http_error
 
 class ManagerMixin(metaclass=ABCMeta):
     """Class to hold the mixin for the managers."""
@@ -42,6 +42,7 @@ class ManagerMixin(metaclass=ABCMeta):
         ['all', 'get', 'create', 'update', 'delete'].
         """
 
+    @can_raise_http_error
     def _all(self, **kwargs):
         """
         Method to fetch all objects.

--- a/plutto/mixins/resource_mixin.py
+++ b/plutto/mixins/resource_mixin.py
@@ -59,3 +59,14 @@ class ResourceMixin(metaclass=ABCMeta):
         self.__dict__.update(object_.__dict__)
         return self
 
+    @can_raise_http_error
+    def _delete(self, **kwargs):
+        """Deletes the resource."""
+        identifier = getattr(self, self.__class__.resource_identifier)
+        resource_delete(
+            client=self._client,
+            path=self._path,
+            id_=self.id,
+            params=kwargs,
+        )
+        return self._handlers.get("delete")(identifier, **kwargs)

--- a/plutto/resource_handlers.py
+++ b/plutto/resource_handlers.py
@@ -63,3 +63,6 @@ def resource_update(client, path, id_, klass, handlers, methods, params):
     )
 
 
+def resource_delete(client, path, id_, params):
+    """Delete a specific instance of a resource."""
+    return client.request(f"{path}/{id_}", method="delete", params=params)

--- a/plutto/resource_handlers.py
+++ b/plutto/resource_handlers.py
@@ -50,3 +50,16 @@ def resource_create(client, path, klass, handlers, methods, params):
     )
 
 
+def resource_update(client, path, id_, klass, handlers, methods, params):
+    """Update a specific instance of a resource."""
+    data = client.request(f"{path}/{id_}", method="patch", json=params)
+    return objetize(
+        klass,
+        client,
+        data,
+        handlers=handlers,
+        methods=methods,
+        path=path,
+    )
+
+

--- a/plutto/resource_handlers.py
+++ b/plutto/resource_handlers.py
@@ -37,3 +37,16 @@ def resource_get(client, path, id_, klass, handlers, methods, resource, params):
     )
 
 
+def resource_create(client, path, klass, handlers, methods, params):
+    """Create a new instance of a resource."""
+    data = client.request(path, method="post", json=params)
+    return objetize(
+        klass,
+        client,
+        data,
+        handlers=handlers,
+        methods=methods,
+        path=path,
+    )
+
+

--- a/plutto/resource_handlers.py
+++ b/plutto/resource_handlers.py
@@ -22,3 +22,18 @@ def resource_all(client, path, klass, handlers, methods, resource, params):
         )
         for element in data
     ]
+
+
+def resource_get(client, path, id_, klass, handlers, methods, resource, params):
+    """Fetch a specific instance of a resource."""
+    data = client.request(f"{path}/{id_}", method="get", params=params)[resource]
+    return objetize(
+        klass,
+        client,
+        data,
+        handlers=handlers,
+        methods=methods,
+        path=path,
+    )
+
+

--- a/plutto/utils.py
+++ b/plutto/utils.py
@@ -1,8 +1,12 @@
 from importlib import import_module
 
+from plutto.errors import PluttoError
+
+
 def singularize(string):
     """Remove the last 's' from a string if exists."""
     return string.rstrip("s")
+
 
 def pluralize(string):
     """Add an 's' to a string if it doesn't already end with 's'."""
@@ -10,9 +14,11 @@ def pluralize(string):
         return string
     return string + "s"
 
+
 def snake_to_pascal(snake_string):
     """Convert a snake_case string to PascalCase."""
     return ''.join(word.title() for word in snake_string.split('_'))
+
 
 def get_resource_class(snake_resource_name, value={}):
     """
@@ -26,6 +32,16 @@ def get_resource_class(snake_resource_name, value={}):
         except AttributeError:
             return getattr(module, "GenericPluttoResource")
     return type(value)
+
+
+def get_error_class(function):
+    """
+    Given an error name (in snake case), return the appropiate
+    error class.
+    """
+    module = import_module("plutto.errors")
+    return getattr(module, snake_to_pascal(function), PluttoError)
+
 
 def objetize(klass, client, data, handlers={}, methods=[], path=None):
     """Transform the :data: object into an object with class :klass:"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,3 +88,14 @@ def patch_http_client(monkeypatch):
                 }
             }
 
+    class MockClient(httpx.Client):
+        def request(self, method, url, params=None, json=None, **kwargs):
+            query = url.split("?")[-1].split("&") if "?" in url else []
+            inner_params = {y[0]: y[1] for y in (x.split("=") for x in query)}
+            complete_params = {**inner_params, **({} if params is None else params)}
+            usable_url = url.split("//")[-1].split("/", 1)[-1].split("?")[0]
+            return MockResponse(
+                method, self.base_url, usable_url, complete_params, json
+            )
+
+    monkeypatch.setattr(httpx, "Client", MockClient)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,90 @@
+"""
+Module to hold all the fixtures and stuff that needs to get auto-imported
+by PyTest.
+"""
+
+from json.decoder import JSONDecodeError
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def patch_http_error(monkeypatch):
+    class MockResponse:
+        def __init__(self):
+            pass
+
+        def json(self):
+            return {
+                "error": {
+                    "type": "api_error",
+                    "message": "This is a test error message",
+                }
+            }
+
+    class MockHTTPError(httpx.HTTPError):
+        def __init__(self, message):
+            super().__init__(message)
+            self.response = MockResponse()
+
+    monkeypatch.setattr(httpx, "HTTPError", MockHTTPError)
+
+
+@pytest.fixture
+def patch_http_client(monkeypatch):
+    class MockResponse:
+        def __init__(self, method, base_url, url, params, json):
+            self._base_url = base_url
+            self._params = params
+            page = None
+            if method == "get" and url[-1] == "s":
+                page = int(self._params.pop("page", 1))
+            self._page = page
+            self._method = method
+            self._url = url
+            self._json = json
+
+        @property
+        def headers(self):
+            if self._page is not None and self._page < 10:
+                params = "&".join([*self.formatted_params, f"page={self._page + 1}"])
+                return {
+                    "link": (f"<{self._base_url}/{self._url}?{params}>; " 'rel="next"')
+                }
+            return {}
+
+        @property
+        def formatted_params(self):
+            return [f"{k}={v}" for k, v in self._params.items()]
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            if self._method == "delete":
+                raise JSONDecodeError("Expecting value", "doc", 0)
+            if self._method == "get" and self._url[-1] == "s":
+                return {
+                    "resource_doesnt_exists": [
+                        {
+                            "id": "idx",
+                            "method": self._method,
+                            "url": self._url,
+                            "params": self._params,
+                            "json": self._json,
+                            "page": self._page,
+                    }
+                    for _ in range(10)
+                ]
+            }
+            return {
+                "resource_doesnt_exist": {
+                    "id": "idx",
+                    "method": self._method,
+                    "url": self._url,
+                    "params": self._params,
+                    "json": self._json,
+                }
+            }
+

--- a/tests/mixins/test_manager_mixin.py
+++ b/tests/mixins/test_manager_mixin.py
@@ -24,7 +24,7 @@ class EmptyMockManager(ManagerMixin):
 
 
 class ComplexMockManager(ManagerMixin):
-    resource = "customer"
+    resource = "resource_doesnt_exist"
     methods = ["all", "get", "create", "update", "delete"]
 
     def post_all_handler(self, objects, **kwargs):
@@ -50,9 +50,12 @@ class ComplexMockManager(ManagerMixin):
 
 class TestManagerMixinCreation:
     @pytest.fixture(autouse=True)
+    def patch_http_client(self, patch_http_client):
+        pass
+
     def setup_method(self):
-        self.base_url = "https://sandbox.getplutto.com/api/v1"
-        self.api_key = config("PLUTTO_API_KEY")
+        self.base_url = "https://test.com"
+        self.api_key = "super_secret_api_key"
         self.user_agent = "plutto-python/test"
         self.params = {"first_param": "value1", "second_param": "value2"}
         self.client = Client(
@@ -61,7 +64,7 @@ class TestManagerMixinCreation:
             user_agent=self.user_agent,
             params=self.params,
         )
-        self.path = "/customers"
+        self.path = "/resources"
 
     def test_invalid_methods(self):
         with pytest.raises(TypeError):
@@ -77,15 +80,18 @@ class TestManagerMixinCreation:
             manager.all()
 
     def test_calling_valid_methods(self):
-        manager = ComplexMockManager(self.path, self.client)
-        manager.all()
+        manager = IncompleteMockManager(self.path, self.client)
+        manager.get("id")
 
 
 class TestManagerMixinMethods:
     @pytest.fixture(autouse=True)
+    def patch_http_client(self, patch_http_client):
+        pass
+
     def setup_method(self):
-        self.base_url = "https://sandbox.getplutto.com/api/v1"
-        self.api_key = config("PLUTTO_API_KEY")
+        self.base_url = "https://test.com"
+        self.api_key = "super_secret_api_key"
         self.user_agent = "plutto-python/test"
         self.params = {"first_param": "value1", "second_param": "value2"}
         self.client = Client(
@@ -94,8 +100,8 @@ class TestManagerMixinMethods:
             user_agent=self.user_agent,
             params=self.params,
         )
-        self.path = "/customers"
-        self.manager = ComplexMockManager(self.path, self.client)
+        self.path = "/resources"
+        self.manager = EmptyMockManager(self.path, self.client)
 
     def test_all_not_lazy_method(self):
         objects = self.manager.all(lazy=False)
@@ -106,9 +112,12 @@ class TestManagerMixinMethods:
 
 class TestManagerMixinHandlers:
     @pytest.fixture(autouse=True)
+    def patch_http_client(self, patch_http_client):
+        pass
+
     def setup_method(self):
-        self.base_url = "https://sandbox.getplutto.com/api/v1"
-        self.api_key = config("PLUTTO_API_KEY")
+        self.base_url = "https://test.com"
+        self.api_key = "super_secret_api_key"
         self.user_agent = "plutto-python/test"
         self.params = {"first_param": "value1", "second_param": "value2"}
         self.client = Client(
@@ -117,7 +126,7 @@ class TestManagerMixinHandlers:
             user_agent=self.user_agent,
             params=self.params,
         )
-        self.path = "/customers"
+        self.path = "/resources"
         self.manager = ComplexMockManager(self.path, self.client)
 
     def test_all_handler(self, capsys):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -50,14 +50,17 @@ class TestClientCreationFunctionality:
 
 class TestClientRequestFunctionality:
     @pytest.fixture(autouse=True)
+    def patch_http_request(self, patch_http_client):
+        pass
+
     def setup_method(self):
-        self.base_url = "https://sandbox.getplutto.com/api/v1"
-        self.api_key = config("PLUTTO_API_KEY")
+        self.base_url = "https://test.com"
+        self.api_key = "super_secret_api_key"
         self.user_agent = "plutto-python/test"
         self.params = {"first_param": "value1", "second_param": "value2"}
         self.client = Client(self.base_url, self.api_key, self.user_agent, params=self.params)
 
     def test_get_request(self):
-        data = self.client.request("/customers")
+        data = self.client.request("/movements/3", method="get")
         assert isinstance(data, dict)
-        assert len(data) > 0
+        assert len(data.keys()) > 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,11 @@
+from plutto.errors import PluttoError, AuthenticationError
 from plutto.resources import Customer
 from plutto.utils import (
     singularize,
     pluralize,
     snake_to_pascal,
     get_resource_class,
+    get_error_class,
     objetize,
 )
 
@@ -74,6 +76,18 @@ class TestGetResourceClass:
         resource = "anyone"
         klass = get_resource_class(resource, value=True)
         assert klass is bool
+
+
+class TestGetErrorClass:
+    def test_valid_error(self):
+        error_name = "authentication_error"
+        error = get_error_class(error_name)
+        assert error is AuthenticationError
+
+    def test_invalid_error(self):
+        error_name = "invalid_error"
+        error = get_error_class(error_name)
+        assert error is PluttoError
 
 
 class ExampleClass:


### PR DESCRIPTION
Me di cuenta de que los tests no estaban usando los mocks de las distintas entidades correctamente, por lo que creé el módulo que faltaba para que pytest pudiera hacer todo eso por detrás (`conftest.py`), así no se hacen requests a la api real.