### PR TITLE
Test/fix mocks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,3 +88,14 @@ def patch_http_client(monkeypatch):
                 }
             }
 
+    class MockClient(httpx.Client):
+        def request(self, method, url, params=None, json=None, **kwargs):
+            query = url.split("?")[-1].split("&") if "?" in url else []
+            inner_params = {y[0]: y[1] for y in (x.split("=") for x in query)}
+            complete_params = {**inner_params, **({} if params is None else params)}
+            usable_url = url.split("//")[-1].split("/", 1)[-1].split("?")[0]
+            return MockResponse(
+                method, self.base_url, usable_url, complete_params, json
+            )
+
+    monkeypatch.setattr(httpx, "Client", MockClient)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,90 @@
+"""
+Module to hold all the fixtures and stuff that needs to get auto-imported
+by PyTest.
+"""
+
+from json.decoder import JSONDecodeError
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def patch_http_error(monkeypatch):
+    class MockResponse:
+        def __init__(self):
+            pass
+
+        def json(self):
+            return {
+                "error": {
+                    "type": "api_error",
+                    "message": "This is a test error message",
+                }
+            }
+
+    class MockHTTPError(httpx.HTTPError):
+        def __init__(self, message):
+            super().__init__(message)
+            self.response = MockResponse()
+
+    monkeypatch.setattr(httpx, "HTTPError", MockHTTPError)
+
+
+@pytest.fixture
+def patch_http_client(monkeypatch):
+    class MockResponse:
+        def __init__(self, method, base_url, url, params, json):
+            self._base_url = base_url
+            self._params = params
+            page = None
+            if method == "get" and url[-1] == "s":
+                page = int(self._params.pop("page", 1))
+            self._page = page
+            self._method = method
+            self._url = url
+            self._json = json
+
+        @property
+        def headers(self):
+            if self._page is not None and self._page < 10:
+                params = "&".join([*self.formatted_params, f"page={self._page + 1}"])
+                return {
+                    "link": (f"<{self._base_url}/{self._url}?{params}>; " 'rel="next"')
+                }
+            return {}
+
+        @property
+        def formatted_params(self):
+            return [f"{k}={v}" for k, v in self._params.items()]
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            if self._method == "delete":
+                raise JSONDecodeError("Expecting value", "doc", 0)
+            if self._method == "get" and self._url[-1] == "s":
+                return {
+                    "resource_doesnt_exists": [
+                        {
+                            "id": "idx",
+                            "method": self._method,
+                            "url": self._url,
+                            "params": self._params,
+                            "json": self._json,
+                            "page": self._page,
+                    }
+                    for _ in range(10)
+                ]
+            }
+            return {
+                "resource_doesnt_exist": {
+                    "id": "idx",
+                    "method": self._method,
+                    "url": self._url,
+                    "params": self._params,
+                    "json": self._json,
+                }
+            }
+

--- a/tests/mixins/test_manager_mixin.py
+++ b/tests/mixins/test_manager_mixin.py
@@ -24,7 +24,7 @@ class EmptyMockManager(ManagerMixin):
 
 
 class ComplexMockManager(ManagerMixin):
-    resource = "customer"
+    resource = "resource_doesnt_exist"
     methods = ["all", "get", "create", "update", "delete"]
 
     def post_all_handler(self, objects, **kwargs):
@@ -50,9 +50,12 @@ class ComplexMockManager(ManagerMixin):
 
 class TestManagerMixinCreation:
     @pytest.fixture(autouse=True)
+    def patch_http_client(self, patch_http_client):
+        pass
+
     def setup_method(self):
-        self.base_url = "https://sandbox.getplutto.com/api/v1"
-        self.api_key = config("PLUTTO_API_KEY")
+        self.base_url = "https://test.com"
+        self.api_key = "super_secret_api_key"
         self.user_agent = "plutto-python/test"
         self.params = {"first_param": "value1", "second_param": "value2"}
         self.client = Client(
@@ -61,7 +64,7 @@ class TestManagerMixinCreation:
             user_agent=self.user_agent,
             params=self.params,
         )
-        self.path = "/customers"
+        self.path = "/resources"
 
     def test_invalid_methods(self):
         with pytest.raises(TypeError):
@@ -77,15 +80,18 @@ class TestManagerMixinCreation:
             manager.all()
 
     def test_calling_valid_methods(self):
-        manager = ComplexMockManager(self.path, self.client)
-        manager.all()
+        manager = IncompleteMockManager(self.path, self.client)
+        manager.get("id")
 
 
 class TestManagerMixinMethods:
     @pytest.fixture(autouse=True)
+    def patch_http_client(self, patch_http_client):
+        pass
+
     def setup_method(self):
-        self.base_url = "https://sandbox.getplutto.com/api/v1"
-        self.api_key = config("PLUTTO_API_KEY")
+        self.base_url = "https://test.com"
+        self.api_key = "super_secret_api_key"
         self.user_agent = "plutto-python/test"
         self.params = {"first_param": "value1", "second_param": "value2"}
         self.client = Client(
@@ -94,8 +100,8 @@ class TestManagerMixinMethods:
             user_agent=self.user_agent,
             params=self.params,
         )
-        self.path = "/customers"
-        self.manager = ComplexMockManager(self.path, self.client)
+        self.path = "/resources"
+        self.manager = EmptyMockManager(self.path, self.client)
 
     def test_all_not_lazy_method(self):
         objects = self.manager.all(lazy=False)
@@ -106,9 +112,12 @@ class TestManagerMixinMethods:
 
 class TestManagerMixinHandlers:
     @pytest.fixture(autouse=True)
+    def patch_http_client(self, patch_http_client):
+        pass
+
     def setup_method(self):
-        self.base_url = "https://sandbox.getplutto.com/api/v1"
-        self.api_key = config("PLUTTO_API_KEY")
+        self.base_url = "https://test.com"
+        self.api_key = "super_secret_api_key"
         self.user_agent = "plutto-python/test"
         self.params = {"first_param": "value1", "second_param": "value2"}
         self.client = Client(
@@ -117,7 +126,7 @@ class TestManagerMixinHandlers:
             user_agent=self.user_agent,
             params=self.params,
         )
-        self.path = "/customers"
+        self.path = "/resources"
         self.manager = ComplexMockManager(self.path, self.client)
 
     def test_all_handler(self, capsys):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -50,14 +50,17 @@ class TestClientCreationFunctionality:
 
 class TestClientRequestFunctionality:
     @pytest.fixture(autouse=True)
+    def patch_http_request(self, patch_http_client):
+        pass
+
     def setup_method(self):
-        self.base_url = "https://sandbox.getplutto.com/api/v1"
-        self.api_key = config("PLUTTO_API_KEY")
+        self.base_url = "https://test.com"
+        self.api_key = "super_secret_api_key"
         self.user_agent = "plutto-python/test"
         self.params = {"first_param": "value1", "second_param": "value2"}
         self.client = Client(self.base_url, self.api_key, self.user_agent, params=self.params)
 
     def test_get_request(self):
-        data = self.client.request("/customers")
+        data = self.client.request("/movements/3", method="get")
         assert isinstance(data, dict)
-        assert len(data) > 0
+        assert len(data.keys()) > 0


### PR DESCRIPTION
En este PR se arreglan los mocks de los test. Antes no se estaba fakeando bien los clientes para los tests porque faltaba un archivo para poder usar pytest correctamente