### PR TITLE
Feat/customer permission

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,5 @@ coverage:
       default:
         informational: false
         target: auto
+ignore:
+  - plutto/resources

--- a/plutto/managers/customers_manager.py
+++ b/plutto/managers/customers_manager.py
@@ -1,6 +1,8 @@
 """Module to hold the customers manager."""
 
-from plutto.mixins.manager_mixin import ManagerMixin
+from plutto.mixins import ManagerMixin
+from plutto.resource_handlers import resource_permission
+from plutto.utils import get_resource_class
 
 
 class CustomersManager(ManagerMixin):
@@ -8,3 +10,19 @@ class CustomersManager(ManagerMixin):
 
     resource = "customer"
     methods = ["all", "get", "create", "update", "delete"]
+
+    def permission(self, unique_identifier, permission_name, **kwargs):
+        """Check if the user has the permission with permission_name"""
+        resource = "customer_permission"
+        klass = get_resource_class(resource)
+        object_ = resource_permission(
+            client=self._client,
+            path=self._path,
+            id_=unique_identifier,
+            permission_name=permission_name,
+            klass=klass,
+            resource=resource,
+            params=kwargs,
+        )
+
+        return object_

--- a/plutto/mixins/manager_mixin.py
+++ b/plutto/mixins/manager_mixin.py
@@ -65,7 +65,7 @@ class ManagerMixin(metaclass=ABCMeta):  # pylint: disable=no-self-use
     @can_raise_http_error
     def _get(self, identifier, **kwargs):
         """
-        Return an instanco of the resource being handled by the manager,
+        Return an instance of the resource being handled by the manager,
         indentified by :identifier:.
         """
         klass = get_resource_class(self.__class__.resource)

--- a/plutto/resource_handlers.py
+++ b/plutto/resource_handlers.py
@@ -68,3 +68,17 @@ def resource_update(client, path, id_, klass, handlers, methods, resource, param
 def resource_delete(client, path, id_, params):
     """Delete a specific instance of a resource."""
     return client.request(f"{path}/{id_}", method="delete", params=params)
+
+
+def resource_permission(client, path, id_, permission_name, klass, resource, params):
+    """Fetch the permissions of a specific instance of a resource."""
+    data = client.request(
+        f"{path}/{id_}/has_permission/{permission_name}", method="get", params=params
+    )[resource]
+
+    return objetize(
+        klass,
+        client,
+        data,
+        path=path,
+    )

--- a/plutto/resources/customer_permission.py
+++ b/plutto/resources/customer_permission.py
@@ -1,6 +1,6 @@
 """Module to hold the Permission resource."""
 
-from plutto.mixins.resource_mixin import ResourceMixin
+from plutto.mixins import ResourceMixin
 
 
 class CustomerPermission(ResourceMixin):

--- a/plutto/resources/customer_permission.py
+++ b/plutto/resources/customer_permission.py
@@ -1,0 +1,7 @@
+"""Module to hold the Permission resource."""
+
+from plutto.mixins.resource_mixin import ResourceMixin
+
+
+class CustomerPermission(ResourceMixin):
+    """Represents a Permission resource."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,17 @@ def patch_http_client(monkeypatch):
                         for _ in range(10)
                     ]
                 }
+            if self._method == "get" and self._url[-4:] == "name":
+                return {
+                    "customer_permission": {
+                        "id": "idx",
+                        "method": self._method,
+                        "url": self._url,
+                        "params": self._params,
+                        "json": self._json,
+                    }
+                }
+
             return {
                 "resource_doesnt_exist": {
                     "id": "idx",

--- a/tests/managers/test_customers_manager.py
+++ b/tests/managers/test_customers_manager.py
@@ -1,0 +1,29 @@
+import pytest
+
+from plutto.client import Client
+from plutto.managers import CustomersManager
+from plutto.mixins import ResourceMixin
+
+
+class TestCustomerManagerMethods:
+    @pytest.fixture(autouse=True)
+    def patch_http_client(self, patch_http_client):
+        pass
+
+    def setup_method(self):
+        self.base_url = "https://test.com"
+        self.api_key = "super_secret_api_key"
+        self.user_agent = "plutto-python/test"
+        self.params = {"first_param": "value1", "second_param": "value2"}
+        self.client = Client(
+            base_url=self.base_url,
+            api_key=self.api_key,
+            user_agent=self.user_agent,
+            params=self.params,
+        )
+        self.path = "/resources"
+        self.manager = CustomersManager(self.path, self.client)
+
+    def test_permission_test(self):
+        object_ = self.manager.permission("id", "permission_name")
+        assert isinstance(object_, ResourceMixin)

--- a/tests/mixins/test_resource_mixin.py
+++ b/tests/mixins/test_resource_mixin.py
@@ -1,0 +1,213 @@
+import pytest
+
+from plutto.client import Client
+from plutto.mixins import ResourceMixin
+from plutto.resources import Customer, GenericPluttoResource
+
+
+class EmptyMockResource(ResourceMixin):
+    pass
+
+
+class ComplexMockResource(ResourceMixin):
+    mappings = {"resource": "resource_doesnt_exist"}
+    resource_identifier = "identifier"
+
+
+class TestResourceMixinCreation:
+    @pytest.fixture(autouse=True)
+    def patch_http_client(self, patch_http_client):
+        pass
+
+    def setup_method(self):
+        self.base_url = "https://test.com"
+        self.api_key = "test_api_key"
+        self.user_agent = "plutto-python/test"
+        self.params = {"first_param": "value1", "second_param": "value2"}
+        self.client = Client(
+            self.base_url,
+            self.api_key,
+            self.user_agent,
+            params=self.params,
+        )
+        self.path = "/resources"
+        self.handlers = {
+            "update": lambda object_, identifier: print("Calling update...") or object_,
+            "delete": lambda identifier: print("Calling delete...") or identifier,
+        }
+
+    def test_empty_mock_resource(self):
+        methods = []
+        data = {
+            "id": "id0",
+            "identifier": "identifier0",
+            "resources": [
+                {"id": "id1", "identifier": "identifier1"},
+                {"id": "id2", "identifier": "identifier2"},
+            ],
+            "resource": {"id": "id3", "identifier": "identifier3"},
+        }
+
+        resource = EmptyMockResource(
+            self.client, self.handlers, methods, self.path, **data
+        )
+
+        assert isinstance(resource, ResourceMixin)
+        assert isinstance(resource.resource, GenericPluttoResource)
+        assert resource.resource.id == data["resource"]["id"]
+        assert isinstance(resource.resources, list)
+        for sub_resource in resource.resources:
+            assert isinstance(sub_resource, GenericPluttoResource)
+
+    def test_complex_mock_resource(self):
+        methods = []
+        data = {
+            "id": "id0",
+            "identifier": "identifier0",
+            "resources": [
+                {"id": "id1", "identifier": "identifier1"},
+                {"id": "id2", "identifier": "identifier2"},
+            ],
+            "resource": {"id": "id3", "identifier": "identifier3"},
+        }
+        resource = ComplexMockResource(
+            self.client, self.handlers, methods, self.path, **data
+        )
+        assert isinstance(resource, ResourceMixin)
+        assert isinstance(resource.resource, GenericPluttoResource)
+        assert resource.resource.id == data["resource"]["id"]
+        assert isinstance(resource.resources, list)
+        for sub_resource in resource.resources:
+            assert isinstance(sub_resource, GenericPluttoResource)
+
+    def test_update_delete_methods_access(self):
+        methods = ["delete"]
+        data = {
+            "id": "id0",
+            "identifier": "identifier0",
+            "resources": [
+                {"id": "id1", "identifier": "identifier1"},
+                {"id": "id2", "identifier": "identifier2"},
+            ],
+            "resource": {"id": "id3", "identifier": "identifier3"},
+        }
+        resource = EmptyMockResource(
+            self.client, self.handlers, methods, self.path, **data
+        )
+        assert isinstance(resource, ResourceMixin)
+
+        with pytest.raises(AttributeError):
+            resource.update()
+
+        resource.delete()
+
+
+class TestMixinUpdateAndDeleteMethods:
+    @pytest.fixture(autouse=True)
+    def patch_http_client(self, patch_http_client):
+        pass
+
+    def setup_method(self):
+        self.base_url = "https://test.com"
+        self.api_key = "test_api_key"
+        self.user_agent = "plutto-python/test"
+        self.params = {"first_param": "value1", "second_param": "value2"}
+        self.client = Client(
+            self.base_url,
+            self.api_key,
+            self.user_agent,
+            params=self.params,
+        )
+        self.path = "/resources"
+        self.handlers = {
+            "update": lambda object_, identifier: print("Calling update...") or object_,
+            "delete": lambda identifier: print("Calling delete...") or identifier,
+        }
+
+    def test_complex_mock_resource_delete_method(self, capsys):
+        methods = ["delete"]
+        data = {
+            "id": "id0",
+            "identifier": "identifier0",
+            "resources": [
+                {"id": "id1", "identifier": "identifier1"},
+                {"id": "id2", "identifier": "identifier2"},
+            ],
+            "resource": {"id": "id3", "identifier": "identifier3"},
+        }
+        resource = EmptyMockResource(
+            self.client, self.handlers, methods, self.path, **data
+        )
+        identifier = resource.delete()
+
+        captured = capsys.readouterr().out
+        assert "delete" in captured
+
+        assert identifier != data["identifier"]
+        assert identifier == data["id"]
+
+    def test_empty_mock_resource_delete_method(self, capsys):
+        methods = ["delete"]
+        data = {
+            "id": "id0",
+            "identifier": "identifier0",
+            "resources": [
+                {"id": "id1", "identifier": "identifier1"},
+                {"id": "id2", "identifier": "identifier2"},
+            ],
+            "resource": {"id": "id3", "identifier": "identifier3"},
+        }
+        resource = ComplexMockResource(
+            self.client, self.handlers, methods, self.path, **data
+        )
+        identifier = resource.delete()
+
+        captured = capsys.readouterr().out
+        assert "delete" in captured
+
+        assert identifier != data["id"]
+        assert identifier == data["identifier"]
+
+    def test_complex_mock_resource_update_method(self, capsys):
+        methods = ["update"]
+        data = {
+            "id": "id0",
+            "identifier": "identifier0",
+            "resources": [
+                {"id": "id1", "identifier": "identifier1"},
+                {"id": "id2", "identifier": "identifier2"},
+            ],
+            "resource": {"id": "id3", "identifier": "identifier3"},
+        }
+        resource = EmptyMockResource(
+            self.client, self.handlers, methods, self.path, **data
+        )
+        resource.update("resource_doesnt_exist")
+
+        captured = capsys.readouterr().out
+        assert "update" in captured
+
+        assert data["identifier"] not in resource.url
+        assert data["id"] in resource.url
+
+    def test_empty_mock_resource_update_method(self, capsys):
+        methods = ["update"]
+        data = {
+            "id": "id0",
+            "identifier": "identifier0",
+            "resources": [
+                {"id": "id1", "identifier": "identifier1"},
+                {"id": "id2", "identifier": "identifier2"},
+            ],
+            "resource": {"id": "id3", "identifier": "identifier3"},
+        }
+        resource = ComplexMockResource(
+            self.client, self.handlers, methods, self.path, **data
+        )
+        resource.update("resource_doesnt_exist")
+
+        captured = capsys.readouterr().out
+        assert "update" in captured
+
+        assert data["id"] not in resource.url
+        assert data["identifier"] in resource.url


### PR DESCRIPTION
## Description

Se agregó un método custom para el manager de Customers. Esto con el fin de poder obtener los permisos de un usuario en particular. Se modeló de la misma manera que los otros métodos, separando la responsabilidad del handler en `resource_handlers.py`. Tengo la sensación de que puede ser una separación media innecesaria, porque puede que en ninguna otra parte se tengan que ver cosas de los permisos, si que feliz si me comentas que opinas sobre esta decisión. Finalmente, se agregaron test para `ResourceMixin`

## Requirements

None.

## Additional changes

None.
