### PR TITLE
Feat/r products permission groups

### DIFF
--- a/plutto/core.py
+++ b/plutto/core.py
@@ -8,6 +8,7 @@ from plutto.managers import (
     CustomersManager,
     InvoicesManager,
     MeterEventsManager,
+    PermissionGroupsManager,
     ProductsManager,
     SubscriptionsManager,
 )
@@ -30,6 +31,7 @@ class Plutto:
         self.__meter_events_manager = None
         self.__invoices_manager = None
         self.__products_manager = None
+        self.__permission_groups_manager = None
 
     @property
     def customers(self):
@@ -95,3 +97,16 @@ class Plutto:
     def products(self, value):  # pylint: disable=no-self-use
         raise NameError("Attribute name corresponds to a manager")
 
+    @property
+    def permission_groups(self):
+        """Proxies the permission groups manager."""
+        if self.__permission_groups_manager is None:
+            self.__permission_groups_manager = PermissionGroupsManager(
+                "/permission_groups", self._client
+            )
+
+        return self.__permission_groups_manager
+
+    @permission_groups.setter
+    def permission_groups(self, value):  # pylint: disable=no-self-use
+        raise NameError("Attribute name corresponds to a manager")

--- a/plutto/core.py
+++ b/plutto/core.py
@@ -8,6 +8,7 @@ from plutto.managers import (
     CustomersManager,
     InvoicesManager,
     MeterEventsManager,
+    ProductsManager,
     SubscriptionsManager,
 )
 from plutto.version import __version__
@@ -28,6 +29,7 @@ class Plutto:
         self.__subscriptions_manager = None
         self.__meter_events_manager = None
         self.__invoices_manager = None
+        self.__products_manager = None
 
     @property
     def customers(self):
@@ -80,3 +82,16 @@ class Plutto:
     @invoices.setter
     def invoices(self, value):  # pylint: disable=no-self-use
         raise NameError("Attribute name corresponds to a manager")
+
+    @property
+    def products(self):
+        """Proxies the products manager."""
+        if self.__products_manager is None:
+            self.__products_manager = ProductsManager("/products", self._client)
+
+        return self.__products_manager
+
+    @products.setter
+    def products(self, value):  # pylint: disable=no-self-use
+        raise NameError("Attribute name corresponds to a manager")
+

--- a/plutto/managers/__init__.py
+++ b/plutto/managers/__init__.py
@@ -3,4 +3,5 @@
 from .customers_manager import CustomersManager
 from .invoices_manager import InvoicesManager
 from .meter_events_manager import MeterEventsManager
+from .products_manager import ProductsManager
 from .subscriptions_manager import SubscriptionsManager

--- a/plutto/managers/__init__.py
+++ b/plutto/managers/__init__.py
@@ -3,5 +3,6 @@
 from .customers_manager import CustomersManager
 from .invoices_manager import InvoicesManager
 from .meter_events_manager import MeterEventsManager
+from .permission_groups_manager import PermissionGroupsManager
 from .products_manager import ProductsManager
 from .subscriptions_manager import SubscriptionsManager

--- a/plutto/managers/permission_groups_manager.py
+++ b/plutto/managers/permission_groups_manager.py
@@ -1,0 +1,10 @@
+"""Module to hold the permission groups manager."""
+
+from plutto.mixins import ManagerMixin
+
+
+class PermissionGroupsManager(ManagerMixin):
+    """Class to hold the permission groups manager."""
+
+    resource = "permission_group"
+    methods = ["all"]

--- a/plutto/managers/products_manager.py
+++ b/plutto/managers/products_manager.py
@@ -1,0 +1,10 @@
+"""Module to hold the products manager."""
+
+from plutto.mixins import ManagerMixin
+
+
+class ProductsManager(ManagerMixin):
+    """Class to hold the products manager."""
+
+    resource = "product"
+    methods = ["all"]

--- a/plutto/resources/__init__.py
+++ b/plutto/resources/__init__.py
@@ -5,5 +5,6 @@ from .customer_permission import CustomerPermission
 from .generic_plutto_resource import GenericPluttoResource
 from .invoice import Invoice
 from .meter_event import MeterEventResource
+from .permission_group import PermissionGroup
 from .product import Product
 from .subscription import Subscription

--- a/plutto/resources/__init__.py
+++ b/plutto/resources/__init__.py
@@ -5,4 +5,5 @@ from .customer_permission import CustomerPermission
 from .generic_plutto_resource import GenericPluttoResource
 from .invoice import Invoice
 from .meter_event import MeterEventResource
+from .product import Product
 from .subscription import Subscription

--- a/plutto/resources/permission_group.py
+++ b/plutto/resources/permission_group.py
@@ -1,0 +1,7 @@
+"""Module to hold the permission group resource."""
+
+from plutto.mixins.resource_mixin import ResourceMixin
+
+
+class PermissionGroup(ResourceMixin):
+    """Represents a Permission Group resource."""

--- a/plutto/resources/product.py
+++ b/plutto/resources/product.py
@@ -1,0 +1,7 @@
+"""Module to hold the product resource."""
+
+from plutto.mixins.resource_mixin import ResourceMixin
+
+
+class Product(ResourceMixin):
+    """Represents a Product resource."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,7 +10,6 @@ class TestCorePluttoObject:
         api_key = "test_api_key"
         plutto = Plutto(api_key)
         assert isinstance(plutto._client, Client)
-        assert isinstance(plutto.customers, ManagerMixin)
 
     def test_customers_manager(self):
         # pylint: disable=protected-access
@@ -79,3 +78,20 @@ class TestCorePluttoObject:
         assert plutto.invoices is not None
         assert isinstance(plutto.invoices, ManagerMixin)
         assert isinstance(plutto._Plutto__invoices_manager, ManagerMixin)
+
+    def test_products_manager(self):
+        # pylint: disable=protected-access
+        api_key = "test_api_key"
+        plutto = Plutto(api_key)
+
+        assert plutto._Plutto__products_manager is None
+        assert isinstance(plutto.products, ManagerMixin)
+        assert plutto._Plutto__products_manager is not None
+        assert isinstance(plutto._Plutto__products_manager, ManagerMixin)
+
+        with pytest.raises(NameError):
+            plutto.products = None
+
+        assert plutto.products is not None
+        assert isinstance(plutto.products, ManagerMixin)
+        assert isinstance(plutto._Plutto__products_manager, ManagerMixin)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,3 +95,20 @@ class TestCorePluttoObject:
         assert plutto.products is not None
         assert isinstance(plutto.products, ManagerMixin)
         assert isinstance(plutto._Plutto__products_manager, ManagerMixin)
+
+    def test_permission_groups(self):
+        # pylint: disable=protected-access
+        api_key = "test_api_key"
+        plutto = Plutto(api_key)
+
+        assert plutto._Plutto__permission_groups_manager is None
+        assert isinstance(plutto.permission_groups, ManagerMixin)
+        assert plutto._Plutto__permission_groups_manager is not None
+        assert isinstance(plutto._Plutto__permission_groups_manager, ManagerMixin)
+
+        with pytest.raises(NameError):
+            plutto.permission_groups = None
+
+        assert plutto.permission_groups is not None
+        assert isinstance(plutto.permission_groups, ManagerMixin)
+        assert isinstance(plutto._Plutto__permission_groups_manager, ManagerMixin)


### PR DESCRIPTION
## Description

Se agregan los `all` de _products_ y _permission groups_. Estos son los únicos métodos existentes en la API para ambos recursos

## Requirements

None.

## Additional changes

None.
